### PR TITLE
fix: Adjusted css to make clear where a section starts/ends.

### DIFF
--- a/public/styles/faq.css
+++ b/public/styles/faq.css
@@ -140,15 +140,20 @@ h2 {
     justify-content: center;
     align-items: center;
     margin: auto;
-    padding: 40px 80px;
+    padding: 0px 80px;
     max-width: 1000px;
     text-align: left;
+}
+
+.download-section img {
+    filter: drop-shadow(10px 10px 20px rgba(0, 0, 0, 0.3));
 }
 
 .faq-section {
     padding: 50px 20px;
     display: flex;
     justify-content: center;
+    background-color: var(--gray-section-background);
 }
 
 .faq-container {

--- a/public/styles/global.css
+++ b/public/styles/global.css
@@ -4,6 +4,7 @@
     --gray-font: rgb(185, 185, 185);
     --answer-faq-color: #2c2c2c;
     --font-family: "Poppins", serif;
+    --gray-section-background: rgb(245, 245, 245);
 }
 
 body {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1aa2c216-8953-4ddb-b9fb-69b9eee2e7d0)
Adjusted css to make it clearer that a section ends and another begins.